### PR TITLE
Fix user lookup in MatchingService

### DIFF
--- a/Elderly_Care/src/main/java/kr/spring/care/matching/service/MatchingService.java
+++ b/Elderly_Care/src/main/java/kr/spring/care/matching/service/MatchingService.java
@@ -107,8 +107,11 @@ public class MatchingService {
         if (seniorId != null) {
             senior = seniorRepository.findById(seniorId)
                     .orElseThrow(() -> new NoSuchElementException("해당 노인을 찾을 수 없습니다: " + seniorId));
-            seniorUser = userRepository.findById(senior.getSeniorId())
-                    .orElseThrow(() -> new NoSuchElementException("해당 노인의 사용자 정보를 찾을 수 없습니다: " + seniorId));
+            // Senior 엔티티에서 직접 연관된 User 정보를 가져오도록 수정
+            seniorUser = senior.getUser();
+            if (seniorUser == null) {
+                throw new NoSuchElementException("해당 노인의 사용자 정보를 찾을 수 없습니다: " + seniorId);
+            }
         }
 
         return new MatchingDetail(caregiverUser, caregiver, seniorUser, senior, matching);


### PR DESCRIPTION
## Summary
- fix user retrieval for senior matching details

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683fa346b1d88322857c3f7191b23ebd